### PR TITLE
fix(ui): use Credential Registry in sync and action bar copy

### DIFF
--- a/ui/src/app/admin/sync/sync-management.component.html
+++ b/ui/src/app/admin/sync/sync-management.component.html
@@ -1,7 +1,7 @@
 <div class="l-container">
   <h1 class="t-type-heading1 t-margin-small t-margin-bottom">External Sync</h1>
   <p class="t-type-body t-margin-small t-margin-bottom">
-    Publish RSDs and Collections to the Credential Engine Registry. Sync runs
+    Publish RSDs and Collections to the Credential Registry. Sync runs
     asynchronously; check logs for progress.
   </p>
 
@@ -18,7 +18,7 @@
   <app-system-message
     *ngIf="!configured"
     title="Sync not configured"
-    body="Credential Engine sync is not configured. Set CREDENTIAL_ENGINE_* environment variables to enable."
+    body="Credential Registry sync is not configured. Set CREDENTIAL_ENGINE_* environment variables to enable."
   >
   </app-system-message>
 
@@ -188,7 +188,7 @@
         Unpublish All
       </h2>
       <p class="t-type-body t-margin-small t-margin-bottom">
-        Remove all published skills and collections from the Credential Engine
+        Remove all published skills and collections from the Credential
         Registry. Use to clean up dev/test data. This cannot be undone.
       </p>
       <div class="l-syncActions">
@@ -260,7 +260,7 @@
           <dt><strong>Integration Key</strong></dt>
           <dd>
             Identifies the sync target configuration (e.g. default). Used when
-            multiple Credential Engine destinations exist.
+            multiple Credential Registry destinations exist.
           </dd>
           <dt><strong>Record Type</strong></dt>
           <dd>

--- a/ui/src/app/collection/detail/collection-public/action-bar/horizontal/collection-public-horizontal-action-bar.component.html
+++ b/ui/src/app/collection/detail/collection-public/action-bar/horizontal/collection-public-horizontal-action-bar.component.html
@@ -56,7 +56,7 @@
       <use [attr.xlink:href]="externalLinkIcon"></use>
     </svg>
     <span class="m-actionBarItemHorizontal-x-label m-buttonText">
-      <span class="button-x-text">View on Credential Engine</span>
+      <span class="button-x-text">View on the Credential Registry</span>
     </span>
     <span
       class="m-actionBarItemHorizontal-x-divider m-divider m-divider-large"

--- a/ui/src/app/collection/detail/collection-public/action-bar/vertical/collection-public-vertical-action-bar.component.html
+++ b/ui/src/app/collection/detail/collection-public/action-bar/vertical/collection-public-vertical-action-bar.component.html
@@ -45,7 +45,9 @@
           <use [attr.xlink:href]="externalLinkIcon"></use>
         </svg>
       </span>
-      <span class="m-actionBarItem-x-text">View on Credential Engine</span>
+      <span class="m-actionBarItem-x-text"
+        >View on the Credential Registry</span
+      >
     </a>
   </div>
 </div>

--- a/ui/src/app/collection/detail/manage-collection.component.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.ts
@@ -332,7 +332,7 @@ export class ManageCollectionComponent
     ) {
       actions.push(
         new TableActionDefinition({
-          label: 'Sync to Credential Engine',
+          label: 'Sync to the Credential Registry',
           icon: this.credentialEngineSyncIcon,
           callback: () => this.syncCollectionToCredentialEngine(),
           visible: () =>
@@ -345,7 +345,7 @@ export class ManageCollectionComponent
     if (this.collection?.credentialEngineUrl) {
       actions.push(
         new TableActionDefinition({
-          label: 'View on Credential Engine',
+          label: 'View on the Credential Registry',
           icon: this.externalLinkIcon,
           callback: () =>
             window.open(this.collection!.credentialEngineUrl!, '_blank'),
@@ -416,7 +416,7 @@ export class ManageCollectionComponent
         this.toastService.hideBlockingLoader();
         this.toastService.showToast(
           'Success',
-          'Collection synced to Credential Engine'
+          'Collection synced to the Credential Registry'
         );
         this.reloadCollection();
       },
@@ -424,7 +424,7 @@ export class ManageCollectionComponent
         this.toastService.hideBlockingLoader();
         const msg =
           err?.status === 503
-            ? 'Credential Engine sync is not configured'
+            ? 'Credential Registry sync is not configured'
             : (err?.error?.message ?? err?.message ?? 'Sync failed');
         this.toastService.showToast('Error', msg);
       },

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.html
@@ -113,7 +113,7 @@
       <use [attr.xlink:href]="credentialEngineSyncIcon"></use>
     </svg>
     <span class="m-actionBarItemHorizontal-x-label m-buttonText">
-      <span class="button-x-text">Sync to Credential Engine</span>
+      <span class="button-x-text">Sync to the Credential Registry</span>
     </span>
     <div
       class="m-actionBarItemHorizontal-x-divider m-divider m-divider-large"
@@ -147,7 +147,7 @@
       <use [attr.xlink:href]="externalLinkIcon"></use>
     </svg>
     <span class="m-actionBarItemHorizontal-x-label m-buttonText">
-      <span class="button-x-text">View on Credential Engine</span>
+      <span class="button-x-text">View on the Credential Registry</span>
     </span>
     <div
       class="m-actionBarItemHorizontal-x-divider m-divider m-divider-large"

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.html
@@ -113,7 +113,9 @@
           <use [attr.xlink:href]="credentialEngineSyncIcon"></use>
         </svg>
       </span>
-      <span class="m-actionBarItem-x-text">Sync to Credential Engine</span>
+      <span class="m-actionBarItem-x-text"
+        >Sync to the Credential Registry</span
+      >
     </button>
 
     <a
@@ -128,7 +130,9 @@
           <use [attr.xlink:href]="externalLinkIcon"></use>
         </svg>
       </span>
-      <span class="m-actionBarItem-x-text">View on Credential Engine</span>
+      <span class="m-actionBarItem-x-text"
+        >View on the Credential Registry</span
+      >
     </a>
   </div>
 </div>

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/manage-rich-skill-action-bar.component.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/manage-rich-skill-action-bar.component.ts
@@ -191,7 +191,7 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
         this.toastService.hideBlockingLoader();
         this.toastService.showToast(
           'Success',
-          'Skill synced to Credential Engine'
+          'Skill synced to the Credential Registry'
         );
         this.reloadSkill.emit();
       },
@@ -199,7 +199,7 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
         this.toastService.hideBlockingLoader();
         const msg =
           err?.status === 503
-            ? 'Credential Engine sync is not configured'
+            ? 'Credential Registry sync is not configured'
             : (err?.error?.message ?? err?.message ?? 'Sync failed');
         this.toastService.showToast('Error', msg);
       },

--- a/ui/src/app/richskill/detail/rich-skill-public/action-bar/action-bar-horizontal/public-skill-action-bar-horizontal.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-public/action-bar/action-bar-horizontal/public-skill-action-bar-horizontal.component.html
@@ -54,7 +54,7 @@
       <use [attr.xlink:href]="externalLinkIcon"></use>
     </svg>
     <span class="m-actionBarItemHorizontal-x-label m-buttonText">
-      <span class="button-x-text">View on Credential Engine</span>
+      <span class="button-x-text">View on the Credential Registry</span>
     </span>
     <span
       class="m-actionBarItemHorizontal-x-divider m-divider m-divider-large"

--- a/ui/src/app/richskill/detail/rich-skill-public/action-bar/action-bar-vertical/public-skill-action-bar-vertical.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-public/action-bar/action-bar-vertical/public-skill-action-bar-vertical.component.html
@@ -45,7 +45,9 @@
           <use [attr.xlink:href]="externalLinkIcon"></use>
         </svg>
       </span>
-      <span class="m-actionBarItem-x-text">View on Credential Engine</span>
+      <span class="m-actionBarItem-x-text"
+        >View on the Credential Registry</span
+      >
     </a>
   </div>
 </div>


### PR DESCRIPTION
Credential Engine prefers the label "Credential Registry" for their service. I think this is all the places where that term is used.