### PR TITLE
feat(richskill): add Add to Workspace on manage skill detail action bar

### DIFF
--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.html
@@ -17,6 +17,23 @@
   </button>
 
   <button
+    *ngIf="canAddToWorkspace"
+    type="button"
+    class="m-actionBarItemHorizontal m-actionBarItemHorizontal-secondary"
+    (click)="handleAddToWorkspace()"
+  >
+    <svg class="m-actionBarItemHorizontal-x-icon t-icon">
+      <use [attr.xlink:href]="addToWorkspaceIcon"></use>
+    </svg>
+    <span class="m-actionBarItemHorizontal-x-label m-buttonText">
+      <span class="button-x-text"> Add to Workspace </span>
+    </span>
+    <div
+      class="m-actionBarItemHorizontal-x-divider m-divider m-divider-large"
+    ></div>
+  </button>
+
+  <button
     type="button"
     class="m-actionBarItemHorizontal m-actionBarItemHorizontal-secondary"
     [disabled]="!canSkillCreate"

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.spec.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.spec.ts
@@ -11,8 +11,10 @@ import { RichSkillService } from 'src/app/richskill/service/rich-skill.service';
 import { ToastService } from 'src/app/toast/toast.service';
 import {
   AuthServiceStub,
+  CollectionServiceStub,
   RichSkillServiceStub,
 } from 'test/resource/mock-stubs';
+import { CollectionService } from 'src/app/collection/service/collection.service';
 import { ManageSkillActionBarHorizontalComponent } from './manage-skill-action-bar-horizontal.component';
 
 @Component({
@@ -73,6 +75,7 @@ describe('ManageSkillActionBarHorizontalComponent', () => {
         ToastService,
         { provide: RichSkillService, useClass: RichSkillServiceStub },
         { provide: AuthService, useClass: AuthServiceStub },
+        { provide: CollectionService, useClass: CollectionServiceStub },
       ],
     }).compileComponents();
 

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.ts
@@ -12,6 +12,7 @@ import { RichSkillService } from '../../../../service/rich-skill.service';
 import { ToastService } from '../../../../../toast/toast.service';
 import { AuthService } from '../../../../../auth/auth-service';
 import { SyncService } from '../../../../../admin/sync/sync.service';
+import { CollectionService } from '../../../../../collection/service/collection.service';
 
 @Component({
   selector: 'app-manage-skill-action-bar-horizontal',
@@ -37,7 +38,8 @@ export class ManageSkillActionBarHorizontalComponent extends ManageRichSkillActi
     toastService: ToastService,
     @Inject(LOCALE_ID) locale: string,
     authService: AuthService,
-    syncService: SyncService
+    syncService: SyncService,
+    collectionService: CollectionService
   ) {
     super(
       router,
@@ -45,7 +47,8 @@ export class ManageSkillActionBarHorizontalComponent extends ManageRichSkillActi
       toastService,
       locale,
       authService,
-      syncService
+      syncService,
+      collectionService
     );
   }
 }

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.html
@@ -27,6 +27,20 @@
     <button
       type="button"
       class="m-actionBarItem"
+      (click)="handleAddToWorkspace()"
+      [disabled]="!canAddToWorkspace"
+    >
+      <span class="m-actionBarItem-x-icon">
+        <svg class="t-icon" aria-hidden="true">
+          <use [attr.xlink:href]="addToWorkspaceIcon"></use>
+        </svg>
+      </span>
+      <span class="m-actionBarItem-x-text">Add to Workspace</span>
+    </button>
+
+    <button
+      type="button"
+      class="m-actionBarItem"
       routerLink="../duplicate"
       [disabled]="!canSkillCreate"
     >

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.spec.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.spec.ts
@@ -13,8 +13,10 @@ import { RichSkillService } from 'src/app/richskill/service/rich-skill.service';
 import { ToastService } from 'src/app/toast/toast.service';
 import {
   AuthServiceStub,
+  CollectionServiceStub,
   RichSkillServiceStub,
 } from 'test/resource/mock-stubs';
+import { CollectionService } from 'src/app/collection/service/collection.service';
 import { ManageSkillActionBarVerticalComponent } from './manage-skill-action-bar-vertical.component';
 import any = jasmine.any;
 
@@ -75,6 +77,7 @@ describe('ManageSkillActionBarVerticalComponent', () => {
         ToastService,
         { provide: RichSkillService, useClass: RichSkillServiceStub },
         { provide: AuthService, useClass: AuthServiceStub },
+        { provide: CollectionService, useClass: CollectionServiceStub },
       ],
     }).compileComponents();
 
@@ -194,6 +197,27 @@ describe('ManageSkillActionBarVerticalComponent', () => {
     expect(showToastSpy).toHaveBeenCalledWith(
       'Success!',
       'URL copied to clipboard'
+    );
+  });
+
+  it('handleAddToWorkspace adds skill uuid and shows toast', () => {
+    const collectionService = TestBed.inject(CollectionService);
+    const updateSpy = spyOn(
+      collectionService,
+      'updateSkillsWithResult'
+    ).and.callThrough();
+    spyOn(toastService, 'showBlockingLoader');
+    spyOn(toastService, 'hideBlockingLoader');
+    const showToastSpy = spyOn(toastService, 'showToast');
+
+    childComponent.handleAddToWorkspace();
+
+    expect(updateSpy).toHaveBeenCalled();
+    const [, skillUpdate] = updateSpy.calls.mostRecent().args;
+    expect(skillUpdate.add?.uuids).toEqual(['1234']);
+    expect(showToastSpy).toHaveBeenCalledWith(
+      'Success!',
+      'You added 7 RSDs to the workspace.'
     );
   });
 });

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.ts
@@ -4,17 +4,15 @@ import {
   Inject,
   Input,
   LOCALE_ID,
-  OnInit,
   Output,
 } from '@angular/core';
 import { Router } from '@angular/router';
-import { AppConfig } from '../../../../../app.config';
 import { RichSkillService } from '../../../../service/rich-skill.service';
 import { ToastService } from '../../../../../toast/toast.service';
 import { ManageRichSkillActionBarComponent } from '../manage-rich-skill-action-bar.component';
-import { SvgHelper } from '../../../../../core/SvgHelper';
 import { AuthService } from '../../../../../auth/auth-service';
 import { SyncService } from '../../../../../admin/sync/sync.service';
+import { CollectionService } from '../../../../../collection/service/collection.service';
 
 @Component({
   selector: 'app-manage-skill-action-bar-vertical',
@@ -39,7 +37,8 @@ export class ManageSkillActionBarVerticalComponent extends ManageRichSkillAction
     toastService: ToastService,
     @Inject(LOCALE_ID) locale: string,
     authService: AuthService,
-    syncService: SyncService
+    syncService: SyncService,
+    collectionService: CollectionService
   ) {
     super(
       router,
@@ -47,7 +46,8 @@ export class ManageSkillActionBarVerticalComponent extends ManageRichSkillAction
       toastService,
       locale,
       authService,
-      syncService
+      syncService,
+      collectionService
     );
   }
 }

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/manage-rich-skill-action-bar.component.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/manage-rich-skill-action-bar.component.ts
@@ -16,6 +16,11 @@ import { ApiSkillSummary } from '../../../ApiSkillSummary';
 import { AuthService } from '../../../../auth/auth-service';
 import { ButtonAction } from '../../../../auth/auth-roles';
 import { SyncService } from '../../../../admin/sync/sync.service';
+import { CollectionService } from '../../../../collection/service/collection.service';
+import {
+  ApiSearch,
+  ApiSkillListUpdate,
+} from '../../../service/rich-skill-search.service';
 
 @Component({ template: '' })
 export abstract class ManageRichSkillActionBarComponent implements OnInit {
@@ -40,6 +45,7 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
   credentialEngineSyncIcon: string = SvgHelper.path(SvgIcon.UPLOAD);
   archiveIcon: string = SvgHelper.path(SvgIcon.ARCHIVE);
   dismissIcon: string = SvgHelper.path(SvgIcon.DISMISS);
+  addToWorkspaceIcon: string = SvgHelper.path(SvgIcon.ADD);
 
   canSkillUpdate = false;
   canSkillCreate = false;
@@ -50,6 +56,7 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
   canCollectionSkillsUpdate = false;
   isDraftAndDisabled = false;
   canSyncRecord = false;
+  canAddToWorkspace = false;
 
   constructor(
     protected router: Router,
@@ -57,7 +64,8 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
     protected toastService: ToastService,
     @Inject(LOCALE_ID) protected locale: string,
     private authService: AuthService,
-    protected syncService: SyncService
+    protected syncService: SyncService,
+    protected collectionService: CollectionService
   ) {}
 
   ngOnInit(): void {
@@ -155,6 +163,30 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
       );
   }
 
+  handleAddToWorkspace(): void {
+    this.toastService.showBlockingLoader();
+    this.collectionService.getWorkspace().subscribe({
+      next: workspace => {
+        const skillListUpdate = new ApiSkillListUpdate({
+          add: new ApiSearch({ uuids: [this.skillUuid] }),
+        });
+        this.collectionService
+          .updateSkillsWithResult(workspace.uuid, skillListUpdate)
+          .subscribe({
+            next: result => {
+              if (result) {
+                const message = `You added ${result.modifiedCount} RSDs to the workspace.`;
+                this.toastService.showToast('Success!', message);
+              }
+              this.toastService.hideBlockingLoader();
+            },
+            error: () => this.toastService.hideBlockingLoader(),
+          });
+      },
+      error: () => this.toastService.hideBlockingLoader(),
+    });
+  }
+
   setEnableFlags(): void {
     this.canSkillUpdate = this.authService.isEnabledByRoles(
       ButtonAction.SkillUpdate
@@ -179,6 +211,9 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
     );
     this.canSyncRecord = this.authService.isEnabledByRoles(
       ButtonAction.SyncRecord
+    );
+    this.canAddToWorkspace = this.authService.isEnabledByRoles(
+      ButtonAction.MyWorkspace
     );
 
     this.isDraftAndDisabled = !this.isPublished() && !this.canSkillPublish;


### PR DESCRIPTION
This adds a new Add to Workspace action for staffers in addition to the existing add to collection action to make assembling a new collection easier.

On an individual RSD page (privileged user authenticated) there is a "Add to collection" action but not an "add to workspace". And "Add to collection" is quite multi-step. It opens a second page where there is a search interface for the collection. Then you submit your search, find the collection you want and complete the process of adding the single RSD to that collection. A lot of clicks.
 
I could see a workflow for creating a new collection using My Workspace being:
* Search for RSDs. Results appear across multiple pages and multiple searches
* When you see a likely match, open it in a new tab
* Click through the new tabs you opened across a session and quickly add items to the workspace with a new Add to workspace secondary action.
* It seems like this could meet the need better than a new option to display more stuff in the search view some of the time.
 
I have many tabs open all the time across a few browser windows where I'm performing different tasks, and hearing all the jokes about how everybody always has so many tabs open, it seems most users are pretty comfortable with a multi-tab workflow. 
 