### PR TITLE
readonly: fix: skip ES index creation in readonly profile

### DIFF
--- a/api/src/main/kotlin/edu/wgu/osmt/elasticsearch/ReadOnlyElasticsearchConfig.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/elasticsearch/ReadOnlyElasticsearchConfig.kt
@@ -1,0 +1,82 @@
+package edu.wgu.osmt.elasticsearch
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate
+import org.springframework.data.elasticsearch.core.IndexOperations
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
+
+/**
+ * Overrides [ElasticsearchTemplate] in readonly mode to skip
+ * automatic index creation on startup. The writable (staff)
+ * instance owns index lifecycle; the readonly instance only reads.
+ *
+ * This prevents the race condition where two containers sharing
+ * the same Elasticsearch sidecar both try to create indices
+ * simultaneously, causing [resource_already_exists_exception].
+ */
+@Configuration
+@Profile("readonly")
+class ReadOnlyElasticsearchConfig {
+    private val log =
+        LoggerFactory.getLogger(ReadOnlyElasticsearchConfig::class.java)
+
+    @Bean
+    @Primary
+    fun readOnlyElasticsearchTemplate(client: ElasticsearchClient): ElasticsearchTemplate {
+        log.info(
+            "Readonly mode: ES index auto-creation disabled",
+        )
+        return object : ElasticsearchTemplate(client) {
+            override fun indexOps(clazz: Class<*>): IndexOperations = SkipCreateIndexOperations(super.indexOps(clazz))
+
+            override fun indexOps(index: IndexCoordinates): IndexOperations =
+                SkipCreateIndexOperations(super.indexOps(index))
+        }
+    }
+}
+
+/**
+ * Delegates all [IndexOperations] to [delegate] but makes
+ * index-creation methods no-ops. Read operations pass through.
+ */
+internal class SkipCreateIndexOperations(
+    private val delegate: IndexOperations,
+) : IndexOperations by delegate {
+    private val log =
+        LoggerFactory.getLogger(SkipCreateIndexOperations::class.java)
+
+    override fun create(): Boolean {
+        log.debug("Skipping index create (readonly)")
+        return true
+    }
+
+    override fun create(settings: MutableMap<String, Any>): Boolean {
+        log.debug("Skipping index create with settings (readonly)")
+        return true
+    }
+
+    override fun create(
+        settings: MutableMap<String, Any>,
+        mapping: org.springframework.data.elasticsearch.core.document.Document,
+    ): Boolean {
+        log.debug(
+            "Skipping index create with settings+mapping (readonly)",
+        )
+        return true
+    }
+
+    override fun createWithMapping(): Boolean {
+        log.debug("Skipping createWithMapping (readonly)")
+        return true
+    }
+
+    override fun delete(): Boolean {
+        log.debug("Skipping index delete (readonly)")
+        return true
+    }
+}

--- a/api/src/test/kotlin/edu/wgu/osmt/elasticsearch/SkipCreateIndexOperationsTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/elasticsearch/SkipCreateIndexOperationsTest.kt
@@ -1,0 +1,63 @@
+package edu.wgu.osmt.elasticsearch
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.springframework.data.elasticsearch.core.IndexOperations
+import org.springframework.data.elasticsearch.core.document.Document
+
+class SkipCreateIndexOperationsTest {
+    private val delegate = mock(IndexOperations::class.java)
+    private val wrapper = SkipCreateIndexOperations(delegate)
+
+    @Test
+    fun `create returns true without calling delegate`() {
+        assertTrue(wrapper.create())
+        verifyNoInteractions(delegate)
+    }
+
+    @Test
+    fun `create with settings is a no-op`() {
+        assertTrue(wrapper.create(mutableMapOf()))
+        verifyNoInteractions(delegate)
+    }
+
+    @Test
+    fun `create with settings and mapping is a no-op`() {
+        assertTrue(
+            wrapper.create(mutableMapOf(), Document.create()),
+        )
+        verifyNoInteractions(delegate)
+    }
+
+    @Test
+    fun `createWithMapping is a no-op`() {
+        assertTrue(wrapper.createWithMapping())
+        verifyNoInteractions(delegate)
+    }
+
+    @Test
+    fun `delete is a no-op`() {
+        assertTrue(wrapper.delete())
+        verifyNoInteractions(delegate)
+    }
+
+    @Test
+    fun `exists delegates to real operations`() {
+        `when`(delegate.exists()).thenReturn(true)
+        assertTrue(wrapper.exists())
+        verify(delegate).exists()
+    }
+
+    @Test
+    fun `getMapping delegates to real operations`() {
+        val mapping = mapOf("properties" to emptyMap<String, Any>())
+        `when`(delegate.mapping).thenReturn(mapping)
+
+        wrapper.mapping
+        verify(delegate).mapping
+    }
+}


### PR DESCRIPTION
Created from branch feature/readonly