### PR TITLE
readonly: fix: proper ES readonly bean naming to prevent index creation

### DIFF
--- a/api/src/main/kotlin/edu/wgu/osmt/elasticsearch/ElasticsearchClientManager.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/elasticsearch/ElasticsearchClientManager.kt
@@ -12,6 +12,7 @@ import org.elasticsearch.client.RestClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.ReadingConverter
 import org.springframework.data.convert.WritingConverter
@@ -40,6 +41,7 @@ class ElasticsearchClientManager {
     }
 
     @Bean
+    @Profile("!readonly")
     fun elasticsearchTemplate(): ElasticsearchTemplate = ElasticsearchTemplate(elasticSearchClient())
 
     @Bean

--- a/api/src/main/kotlin/edu/wgu/osmt/elasticsearch/ReadOnlyElasticsearchConfig.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/elasticsearch/ReadOnlyElasticsearchConfig.kt
@@ -4,20 +4,18 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate
 import org.springframework.data.elasticsearch.core.IndexOperations
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
 
 /**
- * Overrides [ElasticsearchTemplate] in readonly mode to skip
- * automatic index creation on startup. The writable (staff)
+ * Overrides the [ElasticsearchTemplate] bean in readonly mode to
+ * skip automatic index creation on startup. The writable (staff)
  * instance owns index lifecycle; the readonly instance only reads.
  *
- * This prevents the race condition where two containers sharing
- * the same Elasticsearch sidecar both try to create indices
- * simultaneously, causing [resource_already_exists_exception].
+ * The bean must be named "elasticsearchTemplate" because
+ * [EnableElasticsearchRepositories] resolves by bean name.
  */
 @Configuration
 @Profile("readonly")
@@ -26,8 +24,7 @@ class ReadOnlyElasticsearchConfig {
         LoggerFactory.getLogger(ReadOnlyElasticsearchConfig::class.java)
 
     @Bean
-    @Primary
-    fun readOnlyElasticsearchTemplate(client: ElasticsearchClient): ElasticsearchTemplate {
+    fun elasticsearchTemplate(client: ElasticsearchClient): ElasticsearchTemplate {
         log.info(
             "Readonly mode: ES index auto-creation disabled",
         )

--- a/api/src/test/kotlin/edu/wgu/osmt/SpringTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/SpringTest.kt
@@ -75,9 +75,27 @@ interface HasElasticsearchReset {
 
     @BeforeEach
     fun resetElasticsearch() {
-        richSkillEsRepo.deleteAll()
-        collectionEsRepo.deleteAll()
-        keywordEsRepo.deleteAll()
-        jobCodeEsRepo.deleteAll()
+        // In readonly mode, indices may not exist (creation is skipped).
+        // Silently ignore NoSuchIndexException to allow tests to proceed.
+        try {
+            richSkillEsRepo.deleteAll()
+        } catch (_: org.springframework.data.elasticsearch.NoSuchIndexException) {
+            // Index doesn't exist, nothing to delete
+        }
+        try {
+            collectionEsRepo.deleteAll()
+        } catch (_: org.springframework.data.elasticsearch.NoSuchIndexException) {
+            // Index doesn't exist, nothing to delete
+        }
+        try {
+            keywordEsRepo.deleteAll()
+        } catch (_: org.springframework.data.elasticsearch.NoSuchIndexException) {
+            // Index doesn't exist, nothing to delete
+        }
+        try {
+            jobCodeEsRepo.deleteAll()
+        } catch (_: org.springframework.data.elasticsearch.NoSuchIndexException) {
+            // Index doesn't exist, nothing to delete
+        }
     }
 }


### PR DESCRIPTION
Created from branch feature/readonly