### PR TITLE
Use public instance URL for authoring canonical links

### DIFF
--- a/ui/src/app/collection/detail/collection-public/collection-public.component.spec.ts
+++ b/ui/src/app/collection/detail/collection-public/collection-public.component.spec.ts
@@ -109,6 +109,14 @@ describe('CollectionPublicComponent', () => {
     expect(component.collectionUrl).toEqual('id1');
   });
 
+  it('collectionUrl uses public api path when publicInstanceUrl is set', () => {
+    AppConfig.settings.publicInstanceUrl = 'https://public.example.com';
+    expect(component.collectionUrl).toEqual(
+      'https://public.example.com/api/collections/uuid1'
+    );
+    AppConfig.settings.publicInstanceUrl = '';
+  });
+
   it('collectionUuid should be correct', () => {
     const curPageCount = 1; // Loaded by ngOnInit
     expect(component.collectionUuid).toEqual('uuid1');

--- a/ui/src/app/collection/detail/collection-public/collection-public.component.ts
+++ b/ui/src/app/collection/detail/collection-public/collection-public.component.ts
@@ -12,6 +12,7 @@ import { ApiSortOrder, KeywordType } from '../../../richskill/ApiSkill';
 import { PublishStatus } from '../../../PublishStatus';
 import { ApiCollection } from '../../ApiCollection';
 import { Title } from '@angular/platform-browser';
+import { canonicalCollectionPublicUrl } from '../../../core/canonical-public-url.utils';
 import { Whitelabelled } from '../../../../whitelabel';
 import { FormControl } from '@angular/forms';
 import { SizePaginationComponent } from '../../../table/skills-library-table/size-pagination/size-pagination.component';
@@ -88,7 +89,10 @@ export class CollectionPublicComponent extends Whitelabelled implements OnInit {
   }
 
   get collectionUrl(): string {
-    return this.collection?.id ?? '';
+    return canonicalCollectionPublicUrl(
+      this.collection?.id ?? '',
+      this.collection?.uuid ?? ''
+    );
   }
 
   get collectionUuid(): string {

--- a/ui/src/app/collection/detail/manage-collection.component.spec.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.spec.ts
@@ -122,6 +122,25 @@ describe('ManageCollectionComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('viewPublishedAction opens relative path without publicInstanceUrl', () => {
+    spyOn(window, 'open');
+    component.uuidParam = 'uuid1';
+    component.viewPublishedAction();
+    expect(window.open).toHaveBeenCalledWith('/collections/uuid1', '_blank');
+  });
+
+  it('viewPublishedAction opens public URL when publicInstanceUrl set', () => {
+    AppConfig.settings.publicInstanceUrl = 'https://public.example.com';
+    spyOn(window, 'open');
+    component.uuidParam = 'uuid1';
+    component.viewPublishedAction();
+    expect(window.open).toHaveBeenCalledWith(
+      'https://public.example.com/collections/uuid1',
+      '_blank'
+    );
+    AppConfig.settings.publicInstanceUrl = '';
+  });
+
   it('collectionHasSkills should be correct', () => {
     component.collection = undefined;
     expect(component.collectionHasSkills).toBeFalsy();

--- a/ui/src/app/collection/detail/manage-collection.component.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.ts
@@ -34,6 +34,7 @@ import { ApiNamedReference, KeywordType } from '../../richskill/ApiSkill';
 import { FilterDropdown } from '../../models/filter-dropdown.model';
 import { KeywordCountPillControl } from '../../core/pill/pill-control';
 import { SyncService } from '../../admin/sync/sync.service';
+import { openPublishedCollectionBrowserUrl } from '../../core/canonical-public-url.utils';
 
 @Component({
   selector: 'app-manage-collection',
@@ -399,8 +400,13 @@ export class ManageCollectionComponent
   }
 
   viewPublishedAction(): void {
-    const url = `/collections/${this.uuidParam}`;
-    window.open(url, '_blank');
+    window.open(
+      openPublishedCollectionBrowserUrl(
+        this.uuidParam ?? '',
+        this.collection?.id ?? ''
+      ),
+      '_blank'
+    );
   }
 
   publishAction(): void {

--- a/ui/src/app/core/canonical-public-url.utils.spec.ts
+++ b/ui/src/app/core/canonical-public-url.utils.spec.ts
@@ -1,0 +1,115 @@
+import { AppConfig } from '../app.config';
+import { DefaultAppConfig } from '../models/app-config.model';
+import {
+  canonicalCollectionPublicUrl,
+  canonicalSkillPublicUrl,
+  openPublishedCollectionBrowserUrl,
+  openPublishedSkillBrowserUrl,
+  replaceCanonicalOrigin,
+  resolveCanonicalPublicUrl,
+} from './canonical-public-url.utils';
+
+describe('canonical-public-url utils', () => {
+  const staffSkill = 'https://osmt-staff.example.com/api/skills/uuid-1';
+  const publicBase = 'https://osmt.example.com';
+
+  beforeEach(() => {
+    AppConfig.settings = new DefaultAppConfig();
+  });
+
+  describe('replaceCanonicalOrigin', () => {
+    it('returns empty for blank canonical URL', () => {
+      expect(replaceCanonicalOrigin('', publicBase)).toBe('');
+      expect(replaceCanonicalOrigin('   ', publicBase)).toBe('');
+    });
+
+    it('returns unchanged when public instance is blank', () => {
+      expect(replaceCanonicalOrigin(staffSkill, '')).toBe(staffSkill);
+    });
+
+    it('replaces origin and preserves path', () => {
+      expect(replaceCanonicalOrigin(staffSkill, publicBase)).toBe(
+        'https://osmt.example.com/api/skills/uuid-1'
+      );
+    });
+
+    it('normalizes trailing slash on public base', () => {
+      expect(replaceCanonicalOrigin(staffSkill, `${publicBase}/`)).toBe(
+        'https://osmt.example.com/api/skills/uuid-1'
+      );
+    });
+  });
+
+  describe('resolveCanonicalPublicUrl', () => {
+    it('uses AppConfig.settings.publicInstanceUrl', () => {
+      AppConfig.settings.publicInstanceUrl = publicBase;
+      expect(resolveCanonicalPublicUrl(staffSkill)).toBe(
+        'https://osmt.example.com/api/skills/uuid-1'
+      );
+    });
+  });
+
+  describe('canonicalSkillPublicUrl', () => {
+    it('returns non-http id unchanged without public base', () => {
+      expect(canonicalSkillPublicUrl('local-id', 'uuid-1')).toBe('local-id');
+    });
+
+    it('builds api URL under public instance without absolute id', () => {
+      AppConfig.settings.publicInstanceUrl = publicBase;
+      expect(canonicalSkillPublicUrl('local-id', 'uuid-1')).toBe(
+        'https://osmt.example.com/api/skills/uuid-1'
+      );
+    });
+  });
+
+  describe('canonicalCollectionPublicUrl', () => {
+    it('returns non-http id unchanged without public base', () => {
+      expect(canonicalCollectionPublicUrl('id1', 'uuid1')).toBe('id1');
+    });
+
+    it('builds api URL under public instance without absolute id', () => {
+      AppConfig.settings.publicInstanceUrl = publicBase;
+      expect(canonicalCollectionPublicUrl('id1', 'uuid1')).toBe(
+        'https://osmt.example.com/api/collections/uuid1'
+      );
+    });
+  });
+
+  describe('openPublishedSkillBrowserUrl', () => {
+    it('uses relative skills path without public base', () => {
+      expect(openPublishedSkillBrowserUrl('uuid-1', '')).toBe('skills/uuid-1');
+    });
+
+    it('opens on public origin when configured', () => {
+      AppConfig.settings.publicInstanceUrl = publicBase;
+      expect(openPublishedSkillBrowserUrl('uuid-1', '')).toBe(
+        'https://osmt.example.com/skills/uuid-1'
+      );
+    });
+
+    it('rewrites absolute canonical URL when configured', () => {
+      AppConfig.settings.publicInstanceUrl = publicBase;
+      expect(
+        openPublishedSkillBrowserUrl(
+          'uuid-1',
+          'https://osmt-staff.example.com/api/skills/uuid-1'
+        )
+      ).toBe('https://osmt.example.com/api/skills/uuid-1');
+    });
+  });
+
+  describe('openPublishedCollectionBrowserUrl', () => {
+    it('uses absolute path without public base', () => {
+      expect(openPublishedCollectionBrowserUrl('uuid1', '')).toBe(
+        '/collections/uuid1'
+      );
+    });
+
+    it('opens on public origin when configured', () => {
+      AppConfig.settings.publicInstanceUrl = publicBase;
+      expect(openPublishedCollectionBrowserUrl('uuid1', '')).toBe(
+        'https://osmt.example.com/collections/uuid1'
+      );
+    });
+  });
+});

--- a/ui/src/app/core/canonical-public-url.utils.ts
+++ b/ui/src/app/core/canonical-public-url.utils.ts
@@ -1,0 +1,117 @@
+import { AppConfig } from '../app.config';
+
+/**
+ * When split deployment is configured, replaces the origin of an absolute API
+ * canonical URL with {@link AppConfig.settings.publicInstanceUrl}.
+ */
+export function replaceCanonicalOrigin(
+  canonicalUrl: string,
+  publicInstanceUrl: string
+): string {
+  const trimmed = canonicalUrl?.trim() ?? '';
+  if (!trimmed) {
+    return '';
+  }
+  const pub = publicInstanceUrl?.trim() ?? '';
+  if (!pub) {
+    return trimmed;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    const base = pub.replace(/\/$/, '');
+    new URL(base);
+    return `${base}${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return trimmed;
+  }
+}
+
+/** Applies runtime {@link AppConfig.settings.publicInstanceUrl}. */
+export function resolveCanonicalPublicUrl(canonicalUrl: string): string {
+  return replaceCanonicalOrigin(
+    canonicalUrl,
+    AppConfig.settings?.publicInstanceUrl ?? ''
+  );
+}
+
+function hasHttpScheme(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+/**
+ * Public canonical skill URL for copy/display: prefers resolved absolute API id,
+ * else builds `/api/skills/{uuid}` on the public instance when configured.
+ */
+export function canonicalSkillPublicUrl(skillId: string, uuid: string): string {
+  const resolved = resolveCanonicalPublicUrl(skillId?.trim() ?? '');
+  if (hasHttpScheme(resolved)) {
+    return resolved;
+  }
+  const pub = AppConfig.settings?.publicInstanceUrl?.trim() ?? '';
+  const id = uuid?.trim() ?? '';
+  if (pub && id) {
+    const base = pub.replace(/\/$/, '');
+    return `${base}/api/skills/${id}`;
+  }
+  return skillId?.trim() ?? '';
+}
+
+/**
+ * Public canonical collection URL for copy/display.
+ */
+export function canonicalCollectionPublicUrl(
+  collectionId: string,
+  uuid: string
+): string {
+  const resolved = resolveCanonicalPublicUrl(collectionId?.trim() ?? '');
+  if (hasHttpScheme(resolved)) {
+    return resolved;
+  }
+  const pub = AppConfig.settings?.publicInstanceUrl?.trim() ?? '';
+  const id = uuid?.trim() ?? '';
+  if (pub && id) {
+    const base = pub.replace(/\/$/, '');
+    return `${base}/api/collections/${id}`;
+  }
+  return collectionId?.trim() ?? '';
+}
+
+/**
+ * Browser URL for opening the published skill SPA from authoring tools.
+ */
+export function openPublishedSkillBrowserUrl(
+  skillUuid: string,
+  skillCanonicalUrl: string
+): string {
+  const trimmed = skillCanonicalUrl?.trim() ?? '';
+  if (hasHttpScheme(trimmed)) {
+    return resolveCanonicalPublicUrl(trimmed);
+  }
+  const pub = AppConfig.settings?.publicInstanceUrl?.trim() ?? '';
+  const id = skillUuid?.trim() ?? '';
+  if (pub && id) {
+    const base = pub.replace(/\/$/, '');
+    return `${base}/skills/${id}`;
+  }
+  return `skills/${id}`;
+}
+
+/**
+ * Browser URL for opening the published collection SPA from authoring tools.
+ */
+export function openPublishedCollectionBrowserUrl(
+  collectionUuid: string,
+  collectionCanonicalUrl: string
+): string {
+  const trimmed = collectionCanonicalUrl?.trim() ?? '';
+  if (hasHttpScheme(trimmed)) {
+    return resolveCanonicalPublicUrl(trimmed);
+  }
+  const pub = AppConfig.settings?.publicInstanceUrl?.trim() ?? '';
+  const id = collectionUuid?.trim() ?? '';
+  if (pub && id) {
+    const base = pub.replace(/\/$/, '');
+    return `${base}/collections/${id}`;
+  }
+  return `/collections/${id}`;
+}

--- a/ui/src/app/richskill/detail/AbstractRichSkillDetailComponent.spec.ts
+++ b/ui/src/app/richskill/detail/AbstractRichSkillDetailComponent.spec.ts
@@ -151,6 +151,37 @@ describe('ConcreteComponent', () => {
     expect(component.getSkillUrl()).toEqual(skill.id);
   });
 
+  it('getSkillUrl uses public api path when publicInstanceUrl is set', () => {
+    const origUuid = skill.uuid;
+    const origId = skill.id;
+    AppConfig.settings.publicInstanceUrl = 'https://public.example.com';
+    component.richSkill = skill;
+    component.richSkill.uuid = 'abc-uuid';
+    component.richSkill.id = 'opaque-id';
+
+    expect(component.getSkillUrl()).toEqual(
+      'https://public.example.com/api/skills/abc-uuid'
+    );
+
+    skill.uuid = origUuid;
+    skill.id = origId;
+    AppConfig.settings.publicInstanceUrl = '';
+  });
+
+  it('getSkillUrl replaces origin when id is absolute URL', () => {
+    const origId = skill.id;
+    AppConfig.settings.publicInstanceUrl = 'https://public.example.com';
+    component.richSkill = skill;
+    component.richSkill.id = 'https://staff.example.com/api/skills/abc-uuid';
+
+    expect(component.getSkillUrl()).toEqual(
+      'https://public.example.com/api/skills/abc-uuid'
+    );
+
+    skill.id = origId;
+    AppConfig.settings.publicInstanceUrl = '';
+  });
+
   it('getPublishedDate should return', () => {
     // Arrange
     component.richSkill = null;

--- a/ui/src/app/richskill/detail/AbstractRichSkillDetailComponent.ts
+++ b/ui/src/app/richskill/detail/AbstractRichSkillDetailComponent.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 import { PublishStatus } from '../../PublishStatus';
 import { QuickLinksHelper } from '../../core/quick-links-helper';
 import { dateformat } from '../../core/DateHelper';
+import { canonicalSkillPublicUrl } from '../../core/canonical-public-url.utils';
 import { Title } from '@angular/platform-browser';
 
 @Component({ template: `` })
@@ -69,7 +70,10 @@ export abstract class AbstractRichSkillDetailComponent
   }
 
   getSkillUrl(): string {
-    return this.richSkill?.id ?? '';
+    return canonicalSkillPublicUrl(
+      this.richSkill?.id ?? '',
+      this.richSkill?.uuid ?? ''
+    );
   }
 
   getPublishedDate(): string {

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.spec.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.spec.ts
@@ -35,7 +35,7 @@ class TestHostComponent {
   mySkillName = 'my skill name';
   mySkillPublicUrl = 'mockUrl';
   myArchived = false;
-  myPublished = false;
+  myPublished: boolean | string = false;
 }
 
 export function createComponent(T: Type<TestHostComponent>): Promise<void> {
@@ -88,6 +88,12 @@ describe('ManageSkillActionBarVerticalComponent', () => {
 
     createComponent(TestHostComponent);
   }));
+
+  afterEach(() => {
+    AppConfig.settings.publicInstanceUrl = '';
+    hostComponent.myPublished = false;
+    hostComponent.mySkillPublicUrl = 'mockUrl';
+  });
 
   it('should be created', () => {
     expect(hostComponent).toBeTruthy();
@@ -175,6 +181,20 @@ describe('ManageSkillActionBarVerticalComponent', () => {
 
     // Assert
     expect(clicked).toBeTruthy();
+  });
+
+  it('handlePublish opens published skill URL when already published', () => {
+    hostComponent.myPublished = '2020-06-25T14:58:46.313Z';
+    hostComponent.mySkillPublicUrl =
+      'https://staff.example.com/api/skills/1234';
+    AppConfig.settings.publicInstanceUrl = 'https://public.example.com';
+    hostFixture.detectChanges();
+    spyOn(window, 'open');
+    childComponent.handlePublish();
+    expect(window.open).toHaveBeenCalledWith(
+      'https://public.example.com/api/skills/1234',
+      '_blank'
+    );
   });
 
   it('handleCopyPublicUrl should return', async () => {

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/manage-rich-skill-action-bar.component.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/manage-rich-skill-action-bar.component.ts
@@ -9,6 +9,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { AppConfig } from '../../../../app.config';
+import { openPublishedSkillBrowserUrl } from '../../../../core/canonical-public-url.utils';
 import { SvgHelper, SvgIcon } from '../../../../core/SvgHelper';
 import { PublishStatus } from '../../../../PublishStatus';
 import { ExtrasSelectedSkillsState } from '../../../../collection/add-skills-collection.component';
@@ -147,8 +148,10 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
           });
       }
     } else {
-      const url = `skills/${this.skillUuid}`;
-      window.open(url, '_blank');
+      window.open(
+        openPublishedSkillBrowserUrl(this.skillUuid, this.skillPublicUrl),
+        '_blank'
+      );
     }
   }
 


### PR DESCRIPTION
Resolve OSMt canonical skill and collection URLs against AppConfig publicInstanceUrl for copy actions and View Published opens from the authoring UI. Add shared canonical-public-url helpers and tests.

Made-with: Cursor